### PR TITLE
Fixed typographical error, changed abilty to ability in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -768,7 +768,7 @@ mineshafts, etc.)
 ```go
 func MobGriefing(d bool) Option
 ```
-MobGriefing enables/disables the abilty of mobs to destroy blocks
+MobGriefing enables/disables the ability of mobs to destroy blocks
 
 #### func  MobLoot
 


### PR DESCRIPTION
@MJKWoolnough, I've corrected a typographical error in the documentation of the [minecraft](https://github.com/MJKWoolnough/minecraft) project. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
